### PR TITLE
NEMO-2057 - timeout on checkout/payment with large # configured tax rates

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -28,9 +28,8 @@ module Spree
     def self.match(order)
       order_zone = order.tax_zone
       return [] unless order_zone
-      all(:include => { :zone => { :zone_members => :zoneable } }).select do |rate|
-        rate_zone = rate.zone
-        rate_zone == order_zone || rate_zone.contains?(order_zone) || rate_zone.default_tax
+      includes(zone: { zone_members: :zoneable }).all.select do |rate|
+        rate.zone == order_zone || rate.zone.contains?(order_zone) || rate.zone.default_tax
       end
     end
 


### PR DESCRIPTION
This performance enhancement fixes page timeouts on the checkout payment step when a large number of tax rates are configured. 

With 54 tax rates configured, dropped average page response (locally) from ~20s (450 sql, dynamic by # tax rates) to ~2s (136 sql, linear to # tax rates). A 90% improvement and safeguard agains larger datasets.
