### PR TITLE
Revert bonobos' changes on choosing best promotion since we don't have line_item level promotion and bonobos' changes caused NEMO-2543

### DIFF
--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -660,11 +660,7 @@ describe Spree::Order do
   end
 
   context "ensure shipments will be updated" do
-    let(:order) { Spree::Order.create }
-
-    before do
-      Spree::Shipment.create!(order: order)
-    end
+    before { Spree::Shipment.create!(order: order) }
 
     it "destroys current shipments" do
       order.ensure_updated_shipments

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -2,15 +2,11 @@ require 'spec_helper'
 require 'benchmark'
 
 describe Spree::Shipment do
-  let(:order) do
-    order = mock_model Spree::Order, backordered?: false,
-                                     canceled?: false,
-                                     can_ship?: true,
-                                     currency: 'USD',
-                                     touch: true,
-                                     all_adjustments: Spree::Adjustment.none
-    order
-  end
+  let(:order) { mock_model Spree::Order, backordered?: false,
+                                         canceled?: false,
+                                         can_ship?: true,
+                                         currency: 'USD',
+                                         touch: true }
   let(:shipping_method) { create(:shipping_method, name: "UPS") }
   let(:shipment) do
     shipment = Spree::Shipment.new


### PR DESCRIPTION
This reverts commit 97bb4f992b50a373d7e6dbccbeff70952cd2c6f9.

Revert "Eliminate need for stubbing."

This reverts commit 506aaa1790c5eebf1ea8b49afd8c7dda5c31cb6b.

Revert "Update comment and move private method down."

This reverts commit b93362b051ac08e393ee9ddf11460ba8760ee547.

Revert "Prevent multiple promotions on the same order"

This reverts commit 5a128a8775b00e4350ea49f8239068215e8f9d46.

Conflicts:
    core/spec/models/spree/item_adjustments_spec.rb

Revert "This also gets initialized with Orders"

This reverts commit 1748111f40cf65200758df59e9e7dcd5f690e0bf.
