### PR TITLE
Reduce the number of cascading touches.

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -11,7 +11,7 @@ module Spree
 
     delegate :weight, :should_track_inventory?, to: :variant
 
-    after_save :conditional_variant_touch
+    after_save :conditional_variant_touch, if: :changed?
     after_touch { variant.touch }
 
     def backordered_inventory_units

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -202,8 +202,12 @@ module Spree
         end
       end
 
+      def default_price_changed?
+        default_price && (default_price.changed? || default_price.new_record?)
+      end
+
       def save_default_price
-        default_price.save if default_price && (default_price.changed? || default_price.new_record?)
+        default_price.save if default_price_changed?
       end
 
       def set_cost_currency


### PR DESCRIPTION
For better performance, don't call `touch` when not
necessary.
- After saving a product, but neither the product nor its
  default price changed, don't touch it.
- After saving a stock item, only touch the variants if the stock
  item changed.

Background: in ActiveRecord, if a product has not changed,
product.save will not write to the DB--but it _will_ fire
the `after_save` callback. In that case there is no need to
touch anything.

Also factored out a method in variant.rb.

_NOTE_ :boom: if PR is approved, let me know so I can submit it back to Spree.
