### PR TITLE
NEMO-2640 products api performance boost

### DIFF
--- a/api/app/views/spree/api/products/show.v1.rabl
+++ b/api/app/views/spree/api/products/show.v1.rabl
@@ -7,8 +7,10 @@ child :master => :master do
   extends "spree/api/variants/small"
 end
 
-child :variants => :variants do
-  extends "spree/api/variants/small"
+unless params[:template] == 'master'
+  child :variants => :variants do
+    extends "spree/api/variants/small"
+  end
 end
 
 child :option_types => :option_types do


### PR DESCRIPTION
provide querystring value to limit products api to master variants only. this is specifically intended to provide better performance for external integrations that don't intend to use variant information, while keeping backward compatibility with default behavior
