### PR TITLE
Improvements to API performance.

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -129,20 +129,25 @@ module Spree
       end
 
       def product_scope
-        variants_associations = [{ option_values: :option_type }, :default_price, :prices, :images]
         if current_api_user.has_spree_role?("admin")
-          scope = Product.with_deleted.accessible_by(current_ability, :read)
-            .includes(:properties, :option_types, variants: variants_associations, master: variants_associations)
+          scope = Product.with_deleted.accessible_by(current_ability, :read).includes(*product_includes)
 
           unless params[:show_deleted]
             scope = scope.not_deleted
           end
         else
-          scope = Product.accessible_by(current_ability, :read).active
-            .includes(:properties, :option_types, variants: variants_associations, master: variants_associations)
+          scope = Product.accessible_by(current_ability, :read).active.includes(*product_includes)
         end
 
         scope
+      end
+
+      def variants_associations
+        [{ option_values: :option_type }, :default_price, :images]
+      end
+
+      def product_includes
+        [ :option_types, variants: variants_associations, master: variants_associations ]
       end
 
       def order_id

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -71,7 +71,7 @@ describe Spree::Api::BaseController do
     json_response.should == { "exception" => "no joy" }
   end
 
-  it "maps symantec keys to nested_attributes keys" do
+  it "maps semantic keys to nested_attributes keys" do
     klass = double(:nested_attributes_options => { :line_items => {},
                                                   :bill_address => {} })
     attributes = { 'line_items' => { :id => 1 },
@@ -81,5 +81,9 @@ describe Spree::Api::BaseController do
     mapped = subject.map_nested_attributes_keys(klass, attributes)
     mapped.has_key?('line_items_attributes').should be_true
     mapped.has_key?('name').should be_true
+  end
+
+  it "lets a subclass override the product associations that are eager-loaded" do
+    controller.respond_to?(:product_includes, true).should be
   end
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -201,10 +201,10 @@ module Spree
     end
 
     def total_on_hand
-      if self.variants_including_master.any? { |v| !v.should_track_inventory? }
+      if any_variants_track_inventory?
         Float::INFINITY
       else
-        self.stock_items.to_a.sum(&:count_on_hand)
+        stock_items.sum(:count_on_hand)
       end
     end
 
@@ -280,6 +280,14 @@ module Spree
 
       def punch_slug
         update(slug: "#{Time.now.to_i}_#{slug}") # punch slug with date prefix to allow reuse of original
+      end
+
+      def any_variants_track_inventory?
+        if variants_including_master.loaded?
+          variants_including_master.any? { |v| !v.should_track_inventory? }
+        else
+          Spree::Config.track_inventory_levels && variants_including_master.where(track_inventory: true).any?
+        end
       end
 
   end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -440,8 +440,8 @@ describe Spree::Product do
     end
 
     it 'should return sum of stock items count_on_hand' do
-      product = build(:product)
-      product.stub stock_items: [double(Spree::StockItem, count_on_hand: 5)]
+      product = create(:product)
+      product.stock_items.first.set_count_on_hand 5
       product.total_on_hand.should eql(5)
     end
   end


### PR DESCRIPTION
Refactor BaseController#product_scope to allow subclasses
to override the associations that are eager-loaded from a product.
In doing so, removed two associations that were eager-loaded
but never referenced (product.properties, variant.prices).

In Product#total_on_hand, don't load and instantiate all the
variants if all we need to know is whether any of them
track inventory. And don't load all the stock_items to sum their
counts on hand.  (Fix to 368b89786).

Speeds up the API (e.g., /api/products, /api/products/1) by a factor of 8
for a product with 1,000 variants.
