### PR TITLE
Eliminate unused eager loading for performance.

### DIFF
--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -149,6 +149,14 @@ module Spree
             params[:product][:shipping_category_id] = id
           end
         end
+
+        def product_includes
+          if params[:template] == 'master'
+            [ :option_types ]
+          else
+            super
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
When hitting /api/products[/id]?template=master,
we don't need to eager load so many associations.

This makes it 30x faster for a product with 1,000 variants.
(From 4 seconds to 131ms.) :space_invader:
