### PR TITLE
Always call registered extension line item comparison hooks

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -331,10 +331,9 @@ module Spree
     def line_item_options_match(line_item, options)
       return true unless options
 
-      options.keys.all? do |key|
-        !self.respond_to?("#{key}_match".to_sym) || 
-        self.send("#{key}_match".to_sym, line_item, options[key]) 
-      end
+      self.line_item_comparison_hooks.all? { |hook| 
+        self.send(hook, line_item, options)
+      }
     end
                                      
     # Creates new tax charges if there are any applicable rates. If prices already

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -40,6 +40,27 @@ describe Spree::Order do
       order.find_line_item_by_variant(@variant1).should_not be_nil
       order.find_line_item_by_variant(mock_model(Spree::Variant)).should be_nil
     end
+
+    context "match line item with options" do
+      before do
+        Spree::Order.register_line_item_comparison_hook(:foos_match)
+      end
+
+      after do
+        # reset to avoid test pollution
+        Spree::Order.line_item_comparison_hooks = Set.new
+      end
+
+      it "matches line item when options match" do
+        order.stub(:foos_match).and_return(true)
+        order.line_item_options_match(@line_items.first, {foos: {bar: :zoo}}).should be_true
+      end
+
+      it "does not match line item without options" do
+        order.stub(:foos_match).and_return(false)
+        order.line_item_options_match(@line_items.first, {}).should be_false
+      end
+    end
   end
 
   context "#payments" do
@@ -540,6 +561,11 @@ describe Spree::Order do
       before do
         Spree::Order.register_line_item_comparison_hook(:foos_match)
         Spree::Variant.stub(:price_modifier_amount).and_return(0.00)
+      end
+
+      after do
+        # reset to avoid test pollution
+        Spree::Order.line_item_comparison_hooks = Set.new
       end
 
       context "2 equal line items" do


### PR DESCRIPTION
This is the same change in this PR https://github.com/spree/spree/pull/5343 that was submitted to spree master.

Please merge https://github.com/godaddy/spree_product_personalization/pull/1 after this PR
