### PR TITLE
NEMO-3533 The order totals for a completed order should not be recalculated

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -21,7 +21,7 @@ module Spree
       event :fill_backorder do
         transition to: :on_hand, from: :backordered
       end
-      after_transition on: :fill_backorder, do: :update_order
+      after_transition on: :fill_backorder, do: :fulfill_order
 
       event :ship do
         transition to: :shipped, if: :allow_ship?
@@ -69,9 +69,9 @@ module Spree
         Spree::Config[:allow_backorder_shipping] || self.on_hand?
       end
 
-      def update_order
+      def fulfill_order
         self.reload
-        order.update!
+        order.fulfill!
       end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -395,6 +395,12 @@ module Spree
       consider_risk
     end
 
+    def fulfill!
+      shipments.each { |shipment| shipment.update!(self) if shipment.persisted? }
+      updater.update_shipment_state
+      save!
+    end
+
     def deliver_order_confirmation_email
       OrderMailer.confirm_email(self.id).deliver
       update_column(:confirmation_delivered, true)

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -6,28 +6,31 @@ describe Spree::InventoryUnit do
 
   context "#backordered_for_stock_item" do
     let(:order) do
-      order = create(:order)
-      order.state = 'complete'
+      order = create(:order, state: 'complete', ship_address: create(:ship_address))
       order.completed_at = Time.now
+      create(:shipment, order: order, stock_location: stock_location)
+      order.shipments.reload
+      create(:line_item, order: order, variant: stock_item.variant)
+      order.line_items.reload
       order.tap(&:save!)
     end
 
     let(:shipment) do
-      shipment = Spree::Shipment.new
-      shipment.stock_location = stock_location
-      shipment.shipping_methods << create(:shipping_method)
-      shipment.order = order
-      # We don't care about this in this test
-      shipment.stub(:ensure_correct_adjustment)
-      shipment.tap(&:save!)
+      order.shipments.first
+    end
+
+    let(:shipping_method) do
+      shipment.shipping_methods.first
     end
 
     let!(:unit) do
-      unit = shipment.inventory_units.build
+      unit = shipment.inventory_units.first
       unit.state = 'backordered'
-      unit.variant_id = stock_item.variant.id
-      unit.order_id = order.id
       unit.tap(&:save!)
+    end
+
+    before do
+      stock_item.set_count_on_hand(-2)
     end
 
     # Regression for #3066
@@ -56,6 +59,13 @@ describe Spree::InventoryUnit do
       other_variant_unit.save!
 
       Spree::InventoryUnit.backordered_for_stock_item(stock_item).should_not include(other_variant_unit)
+    end
+
+    it "does not change shipping cost when fulfilling the order" do
+      current_shipment_cost = shipment.cost
+      shipping_method.calculator.set_preference(:amount, current_shipment_cost + 5.0)
+      stock_item.set_count_on_hand(0)
+      expect(shipment.reload.cost).to eq(current_shipment_cost)
     end
 
     context "other shipments" do


### PR DESCRIPTION
Do not trigger full order update when fulfilling a backordered order.

Same PR that was submitted to Spree: https://github.com/spree/spree/pull/5843
