### PR TITLE
NEMO-3862 "Price inlcude tax" returning a refund line item in checkout and can't continue/Edit or remove item from cart

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -25,11 +25,8 @@ module Spree
 
     # When it comes to computing shipments or line items: same same.
     def compute_shipment_or_line_item(item)
-      if rate.included_in_price
-        deduced_total_by_rate(item.pre_tax_amount, rate)
-      else
-        round_to_two_places(item.discounted_amount * rate.amount)
-      end
+      item_amount = item.pre_tax_amount || item.discounted_amount
+      round_to_two_places(item_amount * rate.amount)
     end
 
     alias_method :compute_shipment, :compute_shipment_or_line_item

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -38,40 +38,21 @@ module Spree
         # Go see the documentation for that method.
         rate.potentially_applicable?(order)
       end
-
-      # Imagine with me this scenario:
-      # You are living in Spain and you have a store which ships to France.
-      # Spain is therefore your default tax rate.
-      # When you ship to Spain, you want the Spanish rate to apply.
-      # When you ship to France, you want the French rate to apply.
-      #
-      # Normally, Spree would notice that you have two potentially applicable
-      # tax rates for one particular item.
-      # When you ship to Spain, only the Spanish one will apply.
-      # When you ship to France, you'll see a Spanish refund AND a French tax.
-      # This little bit of code at the end stops the Spanish refund from appearing.
-      #
-      # For further discussion, see #4397 and #4327.
-      rates.delete_if do |rate|
-        rate.included_in_price? &&
-        (rates - [rate]).map(&:tax_category).include?(rate.tax_category)
-      end
     end
 
     # Pre-tax amounts must be stored so that we can calculate
     # correct rate amounts in the future. For example:
     # https://github.com/spree/spree/issues/4318#issuecomment-34723428
     def self.store_pre_tax_amount(item, rates)
-      if rates.any? { |r| r.included_in_price }
-        case item
-        when Spree::LineItem
-          item_amount = item.discounted_amount
-        when Spree::Shipment
-          item_amount = item.discounted_cost
-        end
-        pre_tax_amount = item_amount / (1 + rates.map(&:amount).sum)
-        item.update_column(:pre_tax_amount, pre_tax_amount)
+      case item
+      when Spree::LineItem
+        item_amount = item.discounted_amount
+      when Spree::Shipment
+        item_amount = item.discounted_cost
       end
+      inclusive_rates_sum = rates.map { |r| r.included_in_price ? r.amount : 0}.sum
+      item_amount = item_amount / (1 + inclusive_rates_sum)
+      item.update_column(:pre_tax_amount, item_amount)
     end
 
     # This method is best described by the documentation on #potentially_applicable?
@@ -195,7 +176,7 @@ module Spree
 
     def default_zone_or_zone_match?(item)
       Zone.default_tax.contains?(item.order.tax_zone) ||
-      item.order.tax_zone == self.zone
+      self.zone.contains?(item.order.tax_zone)
     end
 
     private

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -216,6 +216,8 @@ module Spree
               coupon = Coupon.new(@order)
               coupon.apply
               expect(coupon.success).to be_present
+              Spree::TaxRate.adjust(@order, @order.line_items)
+              @order.update!
               # 3 * ((9 - [9,10].min) + 0)
               @order.reload.total.should == 0
               @order.additional_tax_total.should == 0
@@ -234,6 +236,8 @@ module Spree
               coupon = Coupon.new(@order)
               coupon.apply
               expect(coupon.success).to be_present
+              Spree::TaxRate.adjust(@order, @order.line_items)
+              @order.update!
               # 3 * ( (22 - 10) + 1.2)
               @order.reload.total.should == 39.6
               @order.additional_tax_total.should == 3.6
@@ -259,6 +263,8 @@ module Spree
               coupon = Coupon.new(@order)
               coupon.apply
               expect(coupon.success).to be_present
+              Spree::TaxRate.adjust(@order, @order.line_items)
+              @order.update!
               # 0
               @order.reload.total.should == 0
               @order.additional_tax_total.should == 0

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -169,7 +169,9 @@ describe Spree::TaxRate do
       let(:line_item) do
         stub_model(Spree::LineItem, 
           :tax_category => tax_category_1,
-          :variant => stub_model(Spree::Variant)
+          :variant => stub_model(Spree::Variant),
+          :price => 10,
+          :quantity => 1
         )
       end
 
@@ -294,7 +296,7 @@ describe Spree::TaxRate do
         context "when zone is contained by default tax zone" do
           it "should create two adjustments, one for each tax rate" do
             Spree::TaxRate.adjust(@order, @order.line_items)
-            line_item.adjustments.count.should == 1
+            line_item.adjustments.count.should == 2
           end
 
           it "should not create a tax refund" do
@@ -310,14 +312,14 @@ describe Spree::TaxRate do
             # Zone.stub_chain :default_tax, :contains? => false
             @zone.zone_members.delete_all
           end
-          it "should create an adjustment" do
+          it "should not create an adjustment" do
             Spree::TaxRate.adjust(@order, @order.line_items)
-            line_item.adjustments.charge.count.should == 1
+            line_item.adjustments.charge.count.should == 0
           end
 
-          it "should not create a tax refund for each tax rate" do
+          it "should create a tax refund for each tax rate" do
             Spree::TaxRate.adjust(@order, @order.line_items)
-            line_item.adjustments.credit.count.should == 0
+            line_item.adjustments.credit.count.should == 2
           end
         end
 
@@ -337,7 +339,7 @@ describe Spree::TaxRate do
 
           it "should create a tax refund for each tax rate" do
             Spree::TaxRate.adjust(@order, @order.line_items)
-            line_item.adjustments.credit.count.should == 1
+            line_item.adjustments.credit.count.should == 2
           end
         end
 


### PR DESCRIPTION
1. Calculation of pre_tax_amount should be based on inclusive rates only
2. Calculate tax on pre_tax_amount
3. Fix default_zone_or_zone_match to match country level rates as well
4. allow return both country and state level rates when they're inclusive