### PR TITLE
NEMO-3769 Inventory - No validation warning when trying to add more than qty available when item is already in cart

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -9,8 +9,9 @@ module Spree
 
     def initialize(item)
       @item = item
+
       # Don't attempt to reload the item from the DB if it's not there
-      @item.reload if @item.persisted?
+      @item.reload if @item.instance_of?(Shipment) && @item.persisted?
     end
 
     def update


### PR DESCRIPTION
This issue was fixed in Spree 2.3 (https://github.com/spree/spree/pull/5566).

Just cherry-pick the commit from that PR.