### PR TITLE
NEMO-4599 Whitelist Promotion and Country attributes for Ransack.

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -5,6 +5,8 @@ module Spree
 
     validates :name, :iso_name, presence: true
 
+    self.whitelisted_ransackable_attributes = %w[iso3]
+
     def self.states_required_by_country_id
       states_required = Hash.new(true)
       all.each { |country| states_required[country.id.to_s]= country.states_required }

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -22,7 +22,7 @@ module Spree
 
     before_save :normalize_blank_values
 
-    self.whitelisted_ransackable_attributes = ['code', 'path', 'promotion_category_id']
+    self.whitelisted_ransackable_attributes = ['code', 'path', 'promotion_category_id', 'starts_at', 'expires_at']
 
     def self.advertised
       where(advertise: true)


### PR DESCRIPTION
Related PR: https://github.com/godaddy/spree_product_sale/pull/1

This is needed because the security patch we applied https://spreecommerce.com/blog/security-updates-2015-8-19 is a non-backwards compatible upgrade.