### PR TITLE
NEMO-4885 Order total is incorrect when multiple 'per product coupon' is applied

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -41,6 +41,7 @@ module Spree
     end
 
     after_create :update_adjustable_adjustment_total
+    after_destroy :update_adjustable_adjustment_total
 
     scope :open, -> { where(state: 'open') }
     scope :closed, -> { where(state: 'closed') }


### PR DESCRIPTION
Related PR: https://github.secureserver.net/PC/nemo/pull/626