### PR TITLE
NEMO-4651 Ineligible coupon is not removed in the checkout

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -41,7 +41,7 @@ module Spree
     # +promo_total+        The total value of all promotion adjustments
     # +total+              The so-called "order total."  This is equivalent to +item_total+ plus +adjustment_total+.
     def update_totals
-      order.payment_total = payments.completed.sum(:amount)
+      update_payment_total
       update_item_total
       update_shipment_total
       update_adjustment_total
@@ -56,6 +56,10 @@ module Spree
         shipment.refresh_rates
         shipment.update_amounts
       end
+    end
+
+    def update_payment_total
+      order.payment_total = payments.completed.sum(:amount)
     end
 
     def update_shipment_total

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -184,7 +184,8 @@ module Spree
 
       def update_order
         order.payments.reload
-        order.update!
+        order.updater.update_payment_total
+        order.updater.persist_totals
       end
 
       # Necessary because some payment gateways will refuse payments with

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -107,7 +107,7 @@ module Spree
 
     def adjusted_credits_count(promotable)
       adjustments = promotable.is_a?(Order) ? promotable.all_adjustments : promotable.adjustments
-      credits_count - adjustments.promotion.where(:source_id => actions.pluck(:id)).count
+      credits_count - adjustments.eligible.promotion.where(:source_id => actions.pluck(:id)).count
     end
 
     def credits

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -582,9 +582,9 @@ describe Spree::Payment do
   end
 
   describe "#save" do
-    it "should call order#update!" do
+    it "should call order.updater#update_payment_total" do
       payment = Spree::Payment.create(:amount => 100, :order => order)
-      order.should_receive(:update!)
+      Spree::OrderUpdater.any_instance.should_receive(:update_payment_total)
       payment.save
     end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -254,6 +254,20 @@ describe Spree::Promotion do
       expect(promotion.credits_count).to eq(1)
       expect(promotion.adjusted_credits_count(order)).to eq(0)
     end
+
+    it "counts eligible order level adjustments" do
+      order_adjustment.update_column(:eligible, false)
+      expect(order_adjustment.adjustable).to eq(order)
+      expect(promotion.credits_count).to eq(0)
+      expect(promotion.adjusted_credits_count(order)).to eq(0)
+    end
+
+    it "counts eligible item level adjustments" do
+      item_adjustment.update_column(:eligible, false)
+      expect(item_adjustment.adjustable).to eq(line_item)
+      expect(promotion.credits_count).to eq(0)
+      expect(promotion.adjusted_credits_count(order)).to eq(0)
+    end
   end
 
   context "#products" do


### PR DESCRIPTION
This PR fixes two issues:

1. When a payment is created current codes triggers an order.update! which could modify adjustments, shipments, etc. This is bad. We should not modify an order after shopper review it and decide to make the payment. It should only trigger the update of order payment total. This might be the root cause for some weird cases where a payment total in gateway (PayPal, Stripe, etc) doesn't match the order's total because after it's paid the order might be changed due to the bug.

2. When count promotion usage it should only count eligible adjustments. Current code does that for total use of the promotion but doesn't do the same when counting an order's adjustments.