### PR TITLE
A few fixes for taxon products API

### DIFF
--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -64,7 +64,7 @@ module Spree
         # Returns the products sorted by their position with the classification
         # Products#index does not do the sorting.
         taxon = Spree::Taxon.find(params[:id])
-        @products = taxon.products.ransack(params[:q]).result
+        @products = product_scope.in_taxon(taxon).ransack(params[:q]).result(distinct: true)
         @products = @products.page(params[:page]).per(params[:per_page] || 500)
         render "spree/api/products/index"
       end


### PR DESCRIPTION
1. return products for a taxon and its children (NEMO-5404)
2. do not return dup products (NEMO-5409)
3. do not return inactive products for non-admin user (NEMO-5407)